### PR TITLE
chore: rename to yjs inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# 🛝 Yjs Playground
+# 🛝 Yjs Inspector
 
-[![Build](https://github.com/yjs/yjs-playground/actions/workflows/build.yml/badge.svg)](https://github.com/yjs/yjs-playground/actions/workflows/build.yml)
+[![Build](https://github.com/yjs/yjs-inspector/actions/workflows/build.yml/badge.svg)](https://github.com/yjs/yjs-inspector/actions/workflows/build.yml)
 
 The playground of [Yjs](https://docs.yjs.dev/).
 
 ## ✨ Features
 
 - Connect to a Yjs demo.<br />
-  ![image](https://github.com/yjs/yjs-playground/assets/18554747/144810a2-4da1-4fd3-822d-1f4a015af29f)
+  ![image](https://github.com/yjs/yjs-inspector/assets/18554747/144810a2-4da1-4fd3-822d-1f4a015af29f)
 - Inspect the Yjs document model<br />
-  ![image](https://github.com/yjs/yjs-playground/assets/18554747/edb040f2-6bdd-4c2a-b9cf-43f7eaef08d2)
+  ![image](https://github.com/yjs/yjs-inspector/assets/18554747/edb040f2-6bdd-4c2a-b9cf-43f7eaef08d2)
 - Advanced Filters<br />
   ![image](https://github.com/user-attachments/assets/ecadd716-0163-462e-8762-daf08d964370)
 - Edit the Yjs document model.<br />
-  ![image](https://github.com/yjs/yjs-playground/assets/18554747/46a061e9-3466-46bd-91cc-80e80476de37)
+  ![image](https://github.com/yjs/yjs-inspector/assets/18554747/46a061e9-3466-46bd-91cc-80e80476de37)
 - Export the YDoc snapshot
 - Dark mode

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="./yjs.png" type="image/png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Yjs Playground</title>
+    <title>Yjs Inspector</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yjs-playground",
+  "name": "yjs-inspector",
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -15,7 +15,7 @@ export function Header() {
           </a>
 
           <span className="hidden font-bold sm:inline-block">
-            Yjs Playground
+            Yjs Inspector
           </span>
         </div>
         {/* Placeholder for right side of header */}
@@ -31,7 +31,7 @@ export function Header() {
         <ModeToggle />
         <Button variant="ghost" size="icon" asChild>
           <a
-            href="https://github.com/yjs/yjs-playground"
+            href="https://github.com/yjs/yjs-inspector"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
@dmonad recommended renaming this project from Yjs Playground to Yjs Inspector. I believe this change more accurately reflects the project's focus on parsing Ydoc rather than editing it. In fact, when I initially created this project, it was named Ydoc Playground.

- [x] Modify nouns in the project
- [x] Update project name
- [x] Update domain
- [x] Update the link in the repository details